### PR TITLE
enforcing pickle to use copy of dict while serializing extra context of the notification

### DIFF
--- a/feedly/serializers/activity_serializer.py
+++ b/feedly/serializers/activity_serializer.py
@@ -28,6 +28,13 @@ class ActivitySerializer(BaseSerializer):
                  activity.object_id, activity.target_id or 0]
         extra_context = activity.extra_context.copy()
         pickle_string = ''
+
+        # dictionaries are unsorted data structures
+        # however, using pickled dictionary as a key still differs by letter sequence
+        # this is a temporary solution works in our case
+        import operator
+        extra_context = dict(sorted(extra_context.iteritems(), key=operator.itemgetter(1)))
+
         if extra_context:
             pickle_string = pickle.dumps(extra_context)
         parts += [activity_time, pickle_string]


### PR DESCRIPTION
This fixes a type of notification extra context pickling in our case (remove was failing as key not found). 

Example that satisfies the condition:
import pickle
x = {'order_number': 'X', 'deal_url': 'J'}

pickle.dumps(x)
pickle.dumps(pickle.loads(pickle.dumps(x)))
pickle.dumps(pickle.loads(pickle.dumps(pickle.loads(pickle.dumps(x)))))

Where 1 and 3 are same but second is different.
