### PR TITLE
Update activity_serializer.py

### DIFF
--- a/stream_framework/serializers/activity_serializer.py
+++ b/stream_framework/serializers/activity_serializer.py
@@ -40,7 +40,7 @@ class ActivitySerializer(BaseSerializer):
         actor_id, verb_id, object_id, target_id = map(
             int, parts[:4])
         activity_datetime = epoch_to_datetime(float(parts[4]))
-        pickle_string = str(parts[5])
+        pickle_string = str(','.join(parts[5:]))
         if not target_id:
             target_id = None
         verb = get_verb_by_id(verb_id)


### PR DESCRIPTION
In the function dumps, we are joining the parts by a comma, which may not be the best delimiter in the loads function because extra_contexts may have string fields that contain commas,and since the input of the loads function is a plain string, the list 'parts' in loads would be greater than 5 elements. 

if a user has an extra_context that contains a comma, pickle would throw an EOFError.

the update fetches the rest of the extra_context to be able to unpickle it using pickle. 
