### PR TITLE
Fix aggregated feed unit tests

### DIFF
--- a/stream_framework/tests/feeds/aggregated_feed/base.py
+++ b/stream_framework/tests/feeds/aggregated_feed/base.py
@@ -27,6 +27,8 @@ class TestAggregatedFeed(unittest.TestCase):
             1, LoveVerb, 1, 1, datetime.datetime.now(), {})
         activities = []
         base_time = datetime.datetime.now() - datetime.timedelta(days=10)
+        # make sure that the first portion of activities are created within the same day
+        base_time = base_time.replace(hour=0)
         for x in range(1, 10):
             activity_time = base_time + datetime.timedelta(
                 hours=x)


### PR DESCRIPTION
I noticed that some of aggregated feed unit tests fail when they are executed at the end of the day (between 22 and 23 pm). I investigated this issue and found out that in this case test activities' time is spread into two different days causing the failure of activity aggregation. With this pull request I am granting that the test activities' time will be in the same day, so they will be successfully aggregated.