### PR TITLE
escape semicolons when serializing aggregated activities

### DIFF
--- a/stream_framework/serializers/aggregated_activity_serializer.py
+++ b/stream_framework/serializers/aggregated_activity_serializer.py
@@ -5,6 +5,7 @@ from stream_framework.serializers.utils import check_reserved
 from stream_framework.utils import epoch_to_datetime, datetime_to_epoch
 from stream_framework.serializers.base import BaseAggregatedSerializer
 import six
+import re
 
 
 class AggregatedActivitySerializer(BaseAggregatedSerializer):
@@ -23,7 +24,6 @@ class AggregatedActivitySerializer(BaseAggregatedSerializer):
     #: indicates if dumps returns dehydrated aggregated activities
     dehydrate = True
     identifier = 'v3'
-    reserved_characters = [';', ',', ';;']
     date_fields = ['created_at', 'updated_at', 'seen_at', 'read_at']
 
     activity_serializer_class = ActivitySerializer
@@ -55,7 +55,8 @@ class AggregatedActivitySerializer(BaseAggregatedSerializer):
         else:
             for activity in aggregated.activities:
                 serialized = activity_serializer.dumps(activity)
-                check_reserved(serialized, [';', ';;'])
+                # we use semicolons as delimiter, so need to escape
+                serialized = serialized.replace(";", "\;")
                 serialized_activities.append(serialized)
 
         serialized_activities_part = ';'.join(serialized_activities)
@@ -86,8 +87,10 @@ class AggregatedActivitySerializer(BaseAggregatedSerializer):
                     date_value = epoch_to_datetime(float(v))
                 setattr(aggregated, k, date_value)
 
+            # looks for ; not \;
+            unescaped_semicolons_regex = re.compile("(?<=[^\\\]);")
             # write the activities
-            serializations = parts[5].split(';')
+            serializations = unescaped_semicolons_regex.split(parts[5])
             if self.dehydrate:
                 activity_ids = list(map(int, serializations))
                 aggregated._activity_ids = activity_ids

--- a/stream_framework/storage/redis/connection.py
+++ b/stream_framework/storage/redis/connection.py
@@ -29,7 +29,7 @@ def setup_redis():
             port=config['port'],
             password=config.get('password'),
             db=config['db'],
-            decode_responses=True
+            decode_responses=False # TODO what about Python 3?
         )
         pools[name] = pool
     return pools


### PR DESCRIPTION
I am currently running Stream-Framework with production data, and recently ran into an issue with how stream-framework serialize Aggregated Activities. 

In `aggregated_activity_serializer.py`, we have the line `check_reserved(serialized, [';', ';;'])` that checks if the serialized values contain semicolons.   My use case is creating notifications for when a user (actor) replies (verb) with a comment (object) to another comment (target).  Due to the architecture of the current system, I currently include the body of the comment as `extra_context` to the activity.  The comment body may contain semicolons, and a `SerializationException` is thrown upon serialization.

This PR simply escapes semicolons before deserialization, allowing for semicolons in activities.

I will be able to add some tests for this on Monday — just wanted to put this up first before the weekend :)