### PR TITLE
change celery task decorator to shared_task

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ tests_require = [
 
 install_requires = [
     'redis>=2.8.0',
-    'celery',
+    'celery>=3.0.0',
     'cassandra-driver==2.5.1',
     'six'
 ]

--- a/stream_framework/tasks.py
+++ b/stream_framework/tasks.py
@@ -1,8 +1,8 @@
-from celery import task
+from celery import shared_task
 from stream_framework.activity import Activity, AggregatedActivity
 
 
-@task.task()
+@shared_task
 def fanout_operation(feed_manager, feed_class, user_ids, operation, operation_kwargs):
     '''
     Simple task wrapper for _fanout task
@@ -12,17 +12,17 @@ def fanout_operation(feed_manager, feed_class, user_ids, operation, operation_kw
     return "%d user_ids, %r, %r (%r)" % (len(user_ids), feed_class, operation, operation_kwargs)
 
 
-@task.task()
+@shared_task
 def fanout_operation_hi_priority(feed_manager, feed_class, user_ids, operation, operation_kwargs):
     return fanout_operation(feed_manager, feed_class, user_ids, operation, operation_kwargs)
 
 
-@task.task()
+@shared_task
 def fanout_operation_low_priority(feed_manager, feed_class, user_ids, operation, operation_kwargs):
     return fanout_operation(feed_manager, feed_class, user_ids, operation, operation_kwargs)
 
 
-@task.task()
+@shared_task
 def follow_many(feed_manager, user_id, target_ids, follow_limit):
     feeds = feed_manager.get_feeds(user_id).values()
     target_feeds = map(feed_manager.get_user_feed, target_ids)
@@ -37,7 +37,7 @@ def follow_many(feed_manager, user_id, target_ids, follow_limit):
                 feed.add_many(activities, batch_interface=batch_interface)
 
 
-@task.task()
+@shared_task
 def unfollow_many(feed_manager, user_id, source_ids):
     for feed in feed_manager.get_feeds(user_id).values():
         activities = []


### PR DESCRIPTION
For reusable apps shared_task are used. Also for me with `celery.task.task` decorator, celery was using default settings instead of setting from project.

http://celery.readthedocs.org/en/latest/django/first-steps-with-django.html#using-the-shared-task-decorator