### PR TITLE
Python 3.5 fix

### DIFF
--- a/stream_framework/serializers/utils.py
+++ b/stream_framework/serializers/utils.py
@@ -2,6 +2,7 @@ from stream_framework.exceptions import SerializationException
 
 
 def check_reserved(value, reserved_characters):
-    if any([reserved in value for reserved in reserved_characters]):
-        raise SerializationException(
-            'encountered reserved character %s in %s' % (reserved, value))
+	for reserved in reserved_characters:
+		if reserved in value:
+			raise SerializationException(
+            	'encountered reserved character %s in %s' % (reserved, value))


### PR DESCRIPTION
This fixes an issue where a `NameError` is raised by referencing `reserved` in 

```raise SerializationException('encountered reserved character %s in %s' % (reserved, value))```

On python 3.5 we get the following exception:

`name 'reserved' is not defined` in line 7.