### PR TITLE
Support Cassandra 3.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,6 @@ install:
   - easy_install -U distribute
   - pip install -e .
   - echo "CREATE KEYSPACE stream_framework WITH REPLICATION = { 'class':'SimpleStrategy', 'replication_factor':1 };" | cqlsh
-  - pip install cassandra-driver==CASSANDRA_DRIVER
+  - pip install cassandra-driver==$CASSANDRA_DRIVER
 script:
   - py.test -sl --tb=short stream_framework/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ notifications:
 cache:
   directories:
     - $HOME/.pip-cache/
+env:
+  - CASSANDRA_DRIVER="2.7.2"
+  - CASSANDRA_DRIVER="3.0.0"
 services:
   - redis
   - cassandra
@@ -26,5 +29,6 @@ install:
   - easy_install -U distribute
   - pip install -e .
   - echo "CREATE KEYSPACE stream_framework WITH REPLICATION = { 'class':'SimpleStrategy', 'replication_factor':1 };" | cqlsh
+  - pip install cassandra-driver==CASSANDRA_DRIVER
 script:
   - py.test -sl --tb=short stream_framework/tests

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ It features:
   - Reusable components (You will need to make tradeoffs based on your use cases, Stream Framework doesnt get in your way)
   - Full Cassandra and Redis support
   - The Cassandra storage uses the new CQL3 and Python-Driver packages, which give you access to the latest Cassandra features.
-  - Built for the extremely performant Cassandra 2.1
+  - Build for the extremely performant Cassandra 2.1. 2.2 and 3.3 also pass the test suite, but no production experience.
 
 
 ## Background Articles ##

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ It features:
   - Reusable components (You will need to make tradeoffs based on your use cases, Stream Framework doesnt get in your way)
   - Full Cassandra and Redis support
   - The Cassandra storage uses the new CQL3 and Python-Driver packages, which give you access to the latest Cassandra features.
-  - Built for the extremely performant Cassandra 2.0
+  - Built for the extremely performant Cassandra 2.1
 
 
 ## Background Articles ##

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ tests_require = [
 install_requires = [
     'redis>=2.8.0',
     'celery>=3.0.0',
+    # cassandra-driver 3.0.0 is also supported
     'cassandra-driver==2.7.2',
     'six'
 ]

--- a/stream_framework/storage/cassandra/timeline_storage.py
+++ b/stream_framework/storage/cassandra/timeline_storage.py
@@ -120,7 +120,7 @@ class CassandraTimelineStorage(BaseTimelineStorage):
         parameters = (
             trim_col, self.model._get_keyspace(), self.column_family_name, key, length + 1)
         results = execute(query % parameters)
-        if len(results) < length:
+        if len(results.current_rows) < length:
             return
         trim_ts = (results[-1]['wt'] + results[-2]['wt']) // 2
         delete_query = "DELETE FROM %s.%s USING TIMESTAMP %s WHERE feed_id='%s';"

--- a/stream_framework/storage/cassandra/timeline_storage.py
+++ b/stream_framework/storage/cassandra/timeline_storage.py
@@ -120,7 +120,10 @@ class CassandraTimelineStorage(BaseTimelineStorage):
         parameters = (
             trim_col, self.model._get_keyspace(), self.column_family_name, key, length + 1)
         results = execute(query % parameters)
-        if len(results.current_rows) < length:
+        
+        # compatibility with both cassandra driver 2.7 and 3.0
+        results_length = len(results.current_rows) if hasattr(results, 'current_rows') else len(results)
+        if results_length < length:
             return
         trim_ts = (results[-1]['wt'] + results[-2]['wt']) // 2
         delete_query = "DELETE FROM %s.%s USING TIMESTAMP %s WHERE feed_id='%s';"

--- a/stream_framework/tests/feeds/base.py
+++ b/stream_framework/tests/feeds/base.py
@@ -48,35 +48,32 @@ class TestBaseFeed(unittest.TestCase):
         with patch.object(self.test_feed.timeline_storage, 'add_many') as add_many:
             with patch.object(self.test_feed.timeline_storage, 'trim') as trim:
                 self.test_feed.add(self.activity)
-                add_many.assertCalled()
-                trim.assertCalled()
+                self.assertTrue(add_many.called)
 
     def test_delegate_count_to_storage(self):
         with patch.object(self.test_feed.timeline_storage, 'count') as count:
             self.test_feed.count()
-            count.assertCalled()
             count.assert_called_with(self.test_feed.key)
 
     def test_delegate_delete_to_storage(self):
         with patch.object(self.test_feed.timeline_storage, 'delete') as delete:
             self.test_feed.delete()
-            delete.assertCalled()
             delete.assert_called_with(self.test_feed.key)
 
     def test_delegate_remove_many_to_storage(self):
         with patch.object(self.test_feed.timeline_storage, 'remove_many') as remove_many:
             self.test_feed.remove(self.activity.serialization_id)
-            remove_many.assertCalled()
+            self.assertTrue(remove_many.called)
 
     def test_delegate_add_to_add_many(self):
         with patch.object(self.test_feed, 'add_many') as add_many:
             self.test_feed.add(self.activity.serialization_id)
-            add_many.assertCalled()
+            self.assertTrue(add_many.called)
 
     def test_delegate_remove_to_remove_many(self):
         with patch.object(self.test_feed, 'remove_many') as remove_many:
             self.test_feed.remove(self.activity.serialization_id)
-            remove_many.assertCalled()
+            self.assertTrue(remove_many.called)
 
     def test_slicing_left(self):
         with patch.object(self.test_feed, 'get_activity_slice') as get_activity_slice:

--- a/stream_framework/tests/storage/base.py
+++ b/stream_framework/tests/storage/base.py
@@ -49,19 +49,17 @@ class TestBaseActivityStorageStorage(unittest.TestCase):
     def test_add_to_storage(self):
         with patch.object(self.storage, 'add_to_storage') as add_to_storage:
             self.storage.add(self.activity, *self.args, **self.kwargs)
-            add_to_storage.assert_called()
+            self.assertTrue(add_to_storage.called)
 
     def test_remove_from_storage(self):
         with patch.object(self.storage, 'remove_from_storage') as remove_from_storage:
             self.storage.remove(self.activity)
-            remove_from_storage.assert_called()
             remove_from_storage.assert_called_with(
                 [self.activity.serialization_id], *self.args, **self.kwargs)
 
     def test_get_from_storage(self):
         with patch.object(self.storage, 'get_from_storage') as get_from_storage:
             self.storage.get(self.activity)
-            get_from_storage.assert_called()
             get_from_storage.assert_called_with(
                 [self.activity], *self.args, **self.kwargs)
 


### PR DESCRIPTION
* Test suites successfully runs against cassandra 3.3.0
* Added support for mock 1.3.0 and cassandra-driver 3.0.0
* Travis runs tests for both cassandra-driver 2.7.2 and 3.0.0

Thoughts @tbarbugli 