### PR TITLE
Deps as extras require

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ cache:
   directories:
     - $HOME/.pip-cache/
 env:
-  - CASSANDRA_DRIVER="2.7.2"
-  - CASSANDRA_DRIVER="3.0.0"
+  - DEP="redis"
+  - DEP="cassandra2"
+  - DEP="cassandra3"
 services:
   - redis
   - cassandra
@@ -27,8 +28,7 @@ before_script:
   - echo 'DROP KEYSPACE test_stream_framework;' | /usr/local/cassandra/bin/cqlsh;
 install:
   - easy_install -U distribute
-  - pip install -e .
+  - pip install -e .[$DEP]
   - pip freeze
-  - pip install cassandra-driver==$CASSANDRA_DRIVER
 script:
   - CQLENG_ALLOW_SCHEMA_MANAGEMENT="yes" py.test -sl --tb=short stream_framework/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ cache:
   directories:
     - $HOME/.pip-cache/
 env:
-  - DEP="redis"
-  - DEP="cassandra2"
-  - DEP="cassandra3"
+  - DEP="cassandra2,redis"
+  - DEP="cassandra3,redis"
 services:
   - redis
   - cassandra

--- a/README.md
+++ b/README.md
@@ -56,23 +56,19 @@ Installation through pip is recommended::
 
     $ pip install stream-framework
 
-By default stream-framework installs the required dependencies for redis and cassandra (cassandra-driver 2.7)
+Or you can choose to specify your dependencies (you can add this format to a requirements file)
 
-***Install stream-framework without Cassandra (redis only)***
+```
+$ pip install stream-framework[cassandra2]
+```
 
-    $ pip install stream-framework --install-option="--no-cassandra"
+```
+$ pip install stream-framework[cassandra3]
+```
 
-    or
-
-    $ python setup.py install --no-cassandra
-
-***Install stream-framework and use Cassandra 3***
-
-    $ pip install stream-framework --install-option="--cassandra3"
-
-    or
-
-    $ python setup.py install --cassandra3
+```
+$ pip install stream-framework[redis]
+```
 
 **Authors & Contributors**
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,12 +1,24 @@
 Installation
 ============
 
-Installation is easy using ``pip`` both redis and cassandra dependencies are installed by the setup.
+Installation is easy using ``pip``, choose redis or cassandra dependencies.
 
 
 .. code-block:: bash
 
-    $ pip install Stream-Framework
+    $ pip install Stream-Framework[redis]
+
+or
+
+.. code-block:: bash
+
+    $ pip install Stream-Framework[cassandra2]
+
+or
+
+.. code-block:: bash
+
+    $ pip install Stream-Framework[cassandra3]
 
 
 or get it from source

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,6 @@ import sys
 
 long_description = open('README.md', encoding="utf-8").read()
 
-install_cassandra = "--no-cassandra" not in sys.argv
-install_cassandra_3 = "--cassandra3" in sys.argv
-sys.argv = [a for a in sys.argv if a not in ("--no-cassandra", "--cassandra3")]
 
 tests_require = [
     'Django>=1.3',
@@ -21,16 +18,29 @@ tests_require = [
 ]
 
 install_requires = [
-    'redis>=2.8.0',
     'celery>=3.0.0',
     'six'
 ]
 
-if install_cassandra:
-    if install_cassandra_3:
-        install_requires.append('cassandra-driver==3.0.0')
-    else:
-        install_requires.append('cassandra-driver==2.7.2')
+cassandra2_requires = [
+    'cassandra-driver==2.7.2',
+]
+
+cassandra3_requires = [
+    'cassandra-driver==3.0.0',
+]
+
+redis_requires = [
+    'redis>=2.8.0',
+]
+
+extras_require = {
+    'test': tests_require,
+    'cassandra2': cassandra2_requires,
+    'cassandra3': cassandra3_requires,
+    'redis': redis_requires,
+}
+
 
 class PyTest(TestCommand):
 
@@ -56,7 +66,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=install_requires,
-    extras_require={'test': tests_require},
+    extras_require=extras_require,
     cmdclass={'test': PyTest},
     tests_require=tests_require,
     include_package_data=True,

--- a/stream_framework/__init__.py
+++ b/stream_framework/__init__.py
@@ -4,7 +4,7 @@ __credits__ = ['Thierry Schellenbach, mellowmorning.com, @tschellenbach']
 
 
 __license__ = 'BSD'
-__version__ = '1.3.4'
+__version__ = '1.3.5'
 __maintainer__ = 'Thierry Schellenbach'
 __email__ = 'thierryschellenbach@gmail.com'
 __status__ = 'Production'

--- a/stream_framework/conftest.py
+++ b/stream_framework/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-import redis
 
 
 @pytest.fixture(autouse=True)
@@ -11,6 +10,7 @@ def celery_eager():
 
 @pytest.fixture
 def redis_reset():
+    import redis
     redis.Redis().flushall()
 
 

--- a/stream_framework/tests/serializers.py
+++ b/stream_framework/tests/serializers.py
@@ -3,10 +3,8 @@ from stream_framework.serializers.activity_serializer import ActivitySerializer
 from stream_framework.serializers.aggregated_activity_serializer import \
     AggregatedActivitySerializer, NotificationSerializer
 from stream_framework.serializers.base import BaseSerializer
-from stream_framework.serializers.cassandra.activity_serializer import CassandraActivitySerializer
 from stream_framework.serializers.pickle_serializer import PickleSerializer, \
     AggregatedActivityPickleSerializer
-from stream_framework.storage.cassandra import models
 from stream_framework.tests.utils import FakeActivity
 from functools import partial
 import datetime


### PR DESCRIPTION
Further to the conversation in #174, I saw that there's now an option to install without cassandra `pip install stream-framework --install-option="--no-cassandra"`, however I don't think this option makes it possible to install via a requirements file without cassandra.

This pull request makes it possible to install via

```
$ pip install Stream-Framework[cassandra2]
```

```
$ pip install Stream-Framework[cassandra3]
```

```
$ pip install Stream-Framework[redis]
```

And these options can also be used in a requirements file, eg

```
Stream-Framework[cassandra2]==1.3.4
```