### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ We've included a [Pinterest like example application] [example_app_link] based o
  
 
 [mellowmorning_example]: http://www.mellowmorning.com/2013/10/18/scalable-pinterest-tutorial-feedly-redis/
-[Documentation]: https://stream-framework.readthedocs.org/
+[Documentation]: https://stream-framework.readthedocs.io/
 [Bug Tracker]: https://github.com/tschellenbach/Stream-Framework/issues
 [Code]: http://github.com/tschellenbach/Stream-Framework
 [Travis CI]: http://travis-ci.org/tschellenbach/Stream-Framework/

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -57,7 +57,7 @@ at getstream.io
 
 **Resources**
 
--  `Documentation <https://stream-framework.readthedocs.org/>`__
+-  `Documentation <https://stream-framework.readthedocs.io/>`__
 -  `Bug Tracker <http://github.com/tschellenbach/Feedly/issues>`__
 -  `Code <http://github.com/tschellenbach/Stream-Framework>`__
 -  `Mailing List <https://groups.google.com/group/feedly-python>`__


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.