### PR TITLE
Use extras_require to install different versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
 install:
   - pip install --upgrade pip
   - pip install cassandra-driver==$CASSANDRA_DRIVER
-  - pip install -e .
+  - pip install -e .[redis,cassandra]
   - pip freeze
   - pip install cassandra-driver==$CASSANDRA_DRIVER
 script:

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 
 - make add_to_storage signature consistent on all implementations (args and kwargs were missing for some)
 - Add support for cassandra-driver 3.2.0+
+- Use extras_require pip feature instead of custom install arguments
 
 ==== 1.3.5 ====
 

--- a/README.md
+++ b/README.md
@@ -56,23 +56,20 @@ Installation through pip is recommended::
 
     $ pip install stream-framework
 
-By default stream-framework installs the required dependencies for redis and cassandra (cassandra-driver 2.7)
+By default stream-framework does not install the required dependencies for redis and cassandra
 
-***Install stream-framework without Cassandra (redis only)***
+***Install stream-framework with Redis dependencies***
 
-    $ pip install stream-framework --install-option="--no-cassandra"
+    $ pip install stream-framework[redis]
 
-    or
+***Install stream-framework with Cassandra dependencies***
 
-    $ python setup.py install --no-cassandra
+    $ pip install stream-framework[cassandra]
 
-***Install stream-framework and use Cassandra 3***
+***Install stream-framework with both Redis and Cassandra dependencies***
 
-    $ pip install stream-framework --install-option="--cassandra3"
+    $ pip install stream-framework[redis,cassandra]
 
-    or
-
-    $ python setup.py install --cassandra3
 
 **Authors & Contributors**
 

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,6 @@ import sys
 
 long_description = open('README.md', encoding="utf-8").read()
 
-install_cassandra = "--no-cassandra" not in sys.argv
-install_cassandra_3 = "--cassandra3" in sys.argv
-sys.argv = [a for a in sys.argv if a not in ("--no-cassandra", "--cassandra3")]
-
 tests_require = [
     'Django>=1.3',
     'mock',
@@ -21,16 +17,15 @@ tests_require = [
 ]
 
 install_requires = [
-    'redis>=2.8.0',
     'celery>=3.0.0',
     'six'
 ]
 
-if install_cassandra:
-    if install_cassandra_3:
-        install_requires.append('cassandra-driver==3.0.0')
-    else:
-        install_requires.append('cassandra-driver>=2.7.2')
+extras_require = {
+    'test': tests_require,
+    'redis': ['redis>=2.8.0'],
+    'cassandra': ['cassandra-driver>=2.7.2'],
+}
 
 class PyTest(TestCommand):
 
@@ -56,7 +51,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=install_requires,
-    extras_require={'test': tests_require},
+    extras_require=extras_require,
     cmdclass={'test': PyTest},
     tests_require=tests_require,
     include_package_data=True,

--- a/stream_framework/conftest.py
+++ b/stream_framework/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-import redis
 
 
 @pytest.fixture(autouse=True)
@@ -11,6 +10,7 @@ def celery_eager():
 
 @pytest.fixture
 def redis_reset():
+    import redis
     redis.Redis().flushall()
 
 

--- a/stream_framework/tests/feeds/base.py
+++ b/stream_framework/tests/feeds/base.py
@@ -214,8 +214,9 @@ class TestBaseFeed(unittest.TestCase):
     def test_feed_indexof_large(self):
         assert self.test_feed.count() == 0
         activity_dict = {}
+        now = datetime.datetime.now()
         for i in range(150):
-            moment = datetime.datetime.now() - datetime.timedelta(seconds=i)
+            moment = now - datetime.timedelta(seconds=i)
             activity = self.activity_class(i, LoveVerb, i, i, time=moment)
             activity_dict[i] = activity
         self.test_feed.insert_activities(activity_dict.values())


### PR DESCRIPTION
Partially based on https://github.com/tschellenbach/Stream-Framework/pull/175 and fixes https://github.com/tschellenbach/Stream-Framework/issues/174.

This change could be considered breaking as cassandra and redis are not installed automatically anymore. Also the install arguments that could previously be used have no function anymore.