### PR TITLE
support more redis connection options

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,8 @@
-==== upcoming ====
+==== 1.3.7 ====
+
+- expose Redis connection options
+
+==== 1.3.6 ====
 
 - make add_to_storage signature consistent on all implementations (args and kwargs were missing for some)
 

--- a/stream_framework/__init__.py
+++ b/stream_framework/__init__.py
@@ -4,7 +4,7 @@ __credits__ = ['Thierry Schellenbach, mellowmorning.com, @tschellenbach']
 
 
 __license__ = 'BSD'
-__version__ = '1.3.6'
+__version__ = '1.3.7'
 __maintainer__ = 'Thierry Schellenbach'
 __email__ = 'thierryschellenbach@gmail.com'
 __status__ = 'Production'

--- a/stream_framework/storage/redis/connection.py
+++ b/stream_framework/storage/redis/connection.py
@@ -29,7 +29,13 @@ def setup_redis():
             port=config['port'],
             password=config.get('password'),
             db=config['db'],
-            decode_responses=True
+            decode_responses=config.get('decode_responses', True),
+            # connection options
+            socket_timeout=config.get('socket_timeout', None),
+            socket_connect_timeout=config.get('socket_connect_timeout', None),
+            socket_keepalive=config.get('socket_keepalive', False),
+            socket_keepalive_options=config.get('socket_keepalive_options', None),
+            retry_on_timeout=config.get('retry_on_timeout', False),
         )
         pools[name] = pool
     return pools


### PR DESCRIPTION
Allow custom values for the parameters:

`socket_timeout`
`socket_connect_timeout`
`socket_keepalive`
`socket_keepalive_options`
`retry_on_timeout`
`decode_responses`
