### PR TITLE
Fix millisecond precision instead of seconds in AggregatedActivity

### DIFF
--- a/stream_framework/activity.py
+++ b/stream_framework/activity.py
@@ -193,7 +193,7 @@ class AggregatedActivity(BaseActivity):
 
         :returns: int --the serialization id
         '''
-        milliseconds = str(int(datetime_to_epoch(self.updated_at)) * 1000)
+        milliseconds = str(int(datetime_to_epoch(self.updated_at) * 1000))
         return milliseconds
 
     def get_dehydrated(self):


### PR DESCRIPTION
I am trying to integrate Stream Framework with Redis to my application and noticed that the serialization_id in Aggregated Activities always ends with three zeroes despite claiming to be in millisecond precision due to this line of code