### PR TITLE
AggregatedActivity: Fixed serialization_id not honoring milliseconds

### DIFF
--- a/stream_framework/activity.py
+++ b/stream_framework/activity.py
@@ -193,7 +193,7 @@ class AggregatedActivity(BaseActivity):
 
         :returns: int --the serialization id
         '''
-        milliseconds = str(int(datetime_to_epoch(self.updated_at)) * 1000)
+        milliseconds = str(int(datetime_to_epoch(self.updated_at) * 1000))
         return milliseconds
 
     def get_dehydrated(self):


### PR DESCRIPTION
AggregatedActivity calculation was incorrect. It discard floating point first, then * 1000 (so the rightmost digits will always be 000).