### PR TITLE
Use cPickle where available, instead of pickle

### DIFF
--- a/stream_framework/serializers/activity_serializer.py
+++ b/stream_framework/serializers/activity_serializer.py
@@ -1,9 +1,12 @@
 from stream_framework.serializers.base import BaseSerializer
 from stream_framework.utils import epoch_to_datetime, datetime_to_epoch
 from stream_framework.verbs import get_verb_by_id
-import pickle
 import six
 
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
 class ActivitySerializer(BaseSerializer):
 

--- a/stream_framework/serializers/pickle_serializer.py
+++ b/stream_framework/serializers/pickle_serializer.py
@@ -1,6 +1,9 @@
-import pickle
 from stream_framework.serializers.base import BaseSerializer, BaseAggregatedSerializer
 
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
 class PickleSerializer(BaseSerializer):
 


### PR DESCRIPTION
cPickle is significantly faster than the pure-python pickle module:

```python
In [2]: obj = {'a':'b'}

In [5]: %timeit cPickle.dumps(obj)
1000000 loops, best of 3: 1.29 µs per loop

In [6]: %timeit pickle.dumps(obj)
100000 loops, best of 3: 12.8 µs per loop

In [7]: serialized = cPickle.dumps(obj)

In [9]: %timeit cPickle.loads(serialized)
100000 loops, best of 3: 1.39 µs per loop

In [10]: %timeit pickle.loads(serialized)
100000 loops, best of 3: 14.7 µs per loop
```

With this simple object the performance is a factor of 10 better. The disadvantage of using cPickle is you cannot create custom pickle subclasses, but seeing as we do not do this and there is no option to do this it is safe to import cPickle over pickle, where available. This should lead to a nice speed increase when serializing and deserializing complex activity streams.