### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -294,7 +294,7 @@ epub_copyright = u'2013, Thierry Schellenbach'
 # The format is a list of tuples containing the path and title.
 # epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 # epub_post_files = []
 

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -35,7 +35,7 @@ GetStream.io
 Stream Framework's authors also offer a Saas solution for building feed
 systems at `getstream.io <http://getstream.io/>`__ The hosted service is
 highly optimized and allows you start building your application
-immediatly. It saves you the hastle of maintaining Cassandra, Redis,
+immediately. It saves you the hastle of maintaining Cassandra, Redis,
 Faye, RabbitMQ and Celery workers. Clients are available for
 `Node <https://github.com/GetStream/stream-js>`__,
 `Ruby <https://github.com/GetStream/stream-ruby>`__,

--- a/stream_framework/tests/storage/base.py
+++ b/stream_framework/tests/storage/base.py
@@ -163,7 +163,7 @@ class TestBaseTimelineStorageClass(unittest.TestCase):
     @implementation
     def test_add_many(self):
         results = self.storage.get_slice(self.test_key, 0, None)
-        # make sure no data polution
+        # make sure no data pollution
         assert results == []
         activities = self._build_activity_list(range(3, 0, -1))
         self.storage.add_many(self.test_key, activities)


### PR DESCRIPTION
There are small typos in:
- docs/conf.py
- docs/readme.rst
- stream_framework/tests/storage/base.py

Fixes:
- Should read `that` rather than `shat`.
- Should read `pollution` rather than `polution`.
- Should read `immediately` rather than `immediatly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md